### PR TITLE
Fixed wrong data return

### DIFF
--- a/FX29K.cpp
+++ b/FX29K.cpp
@@ -88,7 +88,7 @@ uint16_t FX29K::getRawBridgeData(void) {
    @brief Get weight in pounds (lbs).
    @return Weight, in pounds.
 */
-float FX29K::getPounds(void) {
+double FX29K::getPounds(void) {
   uint16_t bridgeData = getRawBridgeData();
   uint32_t net = 0;
   int8_t sign = 1;
@@ -100,14 +100,16 @@ float FX29K::getPounds(void) {
     net = _tare - bridgeData;
     sign = -1;
   }
-  return (net * _range / 14000.0) * sign;
+  double temp = net*100;
+  double temp2 = temp/14000;
+  return temp2;
 }
 
 /**
    @brief Get weight in kilograms (kg).
    @return Weight, in kilograms.
 */
-float FX29K::getKilograms(void) {
+double FX29K::getKilograms(void) {
   return getPounds() * 0.453592;
 }
 
@@ -115,7 +117,7 @@ float FX29K::getKilograms(void) {
    @brief Get weight in grams (g).
    @return Weight, in grams.
 */
-float FX29K::getGrams(void) {
+double FX29K::getGrams(void) {
   return getPounds() * 453.592;
 }
 

--- a/FX29K.h
+++ b/FX29K.h
@@ -31,9 +31,9 @@ class FX29K{
   
     uint16_t getRawBridgeData(void);
   
-    float getPounds(void);
-    float getKilograms(void);
-    float getGrams(void);
+    double getPounds(void);
+    double getKilograms(void);
+    double getGrams(void);
   
     void write(TwoWire* i2cPtr, uint8_t i2cAddr, uint8_t* arr, uint8_t byteCount);
     void read(TwoWire* i2cPtr, uint8_t i2cAddr, uint8_t* arr, uint8_t byteCount);


### PR DESCRIPTION
For some reason, the oneline return in getPounds function returns wrong data by some multiplication margin. This fixed it.